### PR TITLE
Split bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,10 @@ const addTag = (s, config) => {
   let openTag = classList.length
     ? `${tag} class="${classList.join(" ")}"`
     : tag;
-  if (s.length === 1) return `<${openTag}>${s}</${tag}>`;
-  return `<${openTag}>${s.slice(
-    0,
-    Math.floor(s.length * split),
-  )}</${tag}>${s.slice(Math.floor(s.length * split))}`;
+  let slicePoint = Math.floor(s.length * split)
+    ? Math.floor(s.length * split)
+    : 1;
+  return `<${openTag}>${s.slice(0, slicePoint)}</${tag}>${s.slice(slicePoint)}`;
 };
 
 const notAWordBoundary = (a, b) => wordRegEx.test(a) === wordRegEx.test(b);

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -26,6 +26,10 @@ test("parse(html, { tag: 'span' }) to add <span> tags to first half of words", (
 `);
 });
 
+test("parse('1') should add a tag around the first (and only) character", () => {
+  expect(parse("1")).toBe("<b>1</b>");
+});
+
 test("parse('1234567890') should add a tag around the first 5 characters", () => {
   expect(parse("1234567890")).toBe("<b>12345</b>67890");
 });


### PR DESCRIPTION
Fix a bug where a low `split` value or low `string.length` resulted in a string being sliced like this`string.slice(0,0)`.